### PR TITLE
Add support for keywords as the keys in the values hashmap

### DIFF
--- a/src/uritemplate_clj/core.clj
+++ b/src/uritemplate_clj/core.clj
@@ -1,6 +1,7 @@
 (ns uritemplate-clj.core
   (:require [ring.util.codec :as codec]
-            [clojure.string :as cs]))
+            [clojure.string :as cs]
+            [clojure.walk :as walk]))
 
 ;Author: Marc Wilhelm Kuester
 ;Code releazed under the Eclipse Public License
@@ -192,10 +193,11 @@
 
 (defn uritemplate ^String [^String template ^clojure.lang.IPersistentMap values]
   "Take a URI template and a map of values and return the resulting URI"
-  (clojure.string/join
-   (map 
-    (fn [token]
-      (if (= \{ (first token))
-        (handle-token (parse-token token) values)
-        token))
-    (tokenize template))))
+  (let [stringly-values (walk/stringify-keys values)]
+    (clojure.string/join
+     (map
+      (fn [token]
+        (if (= \{ (first token))
+          (handle-token (parse-token token) stringly-values)
+          token))
+      (tokenize template)))))

--- a/test/uritemplate_clj/core_test.clj
+++ b/test/uritemplate_clj/core_test.clj
@@ -81,6 +81,35 @@
     (is (= (uritemplate template1 values4) "abc/dir/ep/consil/2003/98/SPA"))
     (is (= (uritemplate template2 values4) "abc/dir/ep,consil/2003/98/SPA"))))
 
+(deftest keyword-values-test
+  (let [template1 "abc{/type}{/agent*}{/year}{/natural_identifier,version,language}"
+        template2 "abc{/type}/{agent*}{/year}{/natural_identifier,version,language}"
+        values1 {:type "dir"
+                 :agent ["ep" "consil"]
+                 :year "2003"
+                 :natural_identifier "98"
+                 :version "R3"
+                 :language "SPA"}
+        values2 {:type "dir"
+                 :agent ["ep" "consil"]
+                 :year "2003"
+                 :natural_identifier "98"}
+        values3 {:type "dir"
+                 :year "2003"
+                 :natural_identifier "98"
+                 "version" "R3"
+                 :language "SPA"}
+        values4 {:type "dir"
+                 "agent" ["ep" "consil"]
+                 :year "2003"
+                 "natural_identifier" "98"
+                 :language "SPA"}]
+    (is (= (uritemplate template1 values1) "abc/dir/ep/consil/2003/98/R3/SPA"))
+    (is (= (uritemplate template1 values2) "abc/dir/ep/consil/2003/98"))
+    (is (= (uritemplate template1 values3) "abc/dir/2003/98/R3/SPA"))
+    (is (= (uritemplate template1 values4) "abc/dir/ep/consil/2003/98/SPA"))
+    (is (= (uritemplate template2 values4) "abc/dir/ep,consil/2003/98/SPA"))))
+
 (deftest ambiguous-template-level3-test
   (let
       [ambiguous-template "/foo{/ba,bar}{/baz,bay}"


### PR DESCRIPTION
I've added support for passing in keywords as the keys in the value replacement hashmap. It's backwards compatible with strings as keys too. I find this makes the library feel a bit more clojure-like. 

Let me know if there is anything else I'd need to do to get this PR merged in