### PR TITLE
Reduce dependency on ring and jetty, to the actual needed ring/ring-codec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,4 @@
             :comment "Author: Marc Wilhelm Küster"}
   :dependencies [[org.clojure/clojure "1.10.2"]
                  [cheshire "5.10.0"]
-                 [ring "1.9.0" :exclusions [org.clojure/clojure]]])
+                 [ring/ring-codec "1.2.0" :exclusions [org.clojure/clojure]]])


### PR DESCRIPTION
This should get rid of unneeded dependencies:

From

```
$ lein deps :tree
 [cheshire "5.10.0"]
   [com.fasterxml.jackson.core/jackson-core "2.10.2"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.10.2"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.10.2"]
   [tigris "0.1.2"]
 [clojure-complete "0.2.5" :exclusions [[org.clojure/clojure]]]
 [nrepl "0.8.3" :exclusions [[org.clojure/clojure]]]
 [org.clojure/clojure "1.10.2"]
   [org.clojure/core.specs.alpha "0.2.56"]
   [org.clojure/spec.alpha "0.2.194"]
 [ring "1.9.0" :exclusions [[org.clojure/clojure]]]
   [ring/ring-core "1.9.0"]
     [commons-fileupload "1.4"]
     [commons-io "2.6"]
     [crypto-equality "1.0.0"]
     [crypto-random "1.2.0"]
     [ring/ring-codec "1.1.2"]
       [commons-codec "1.11"]
   [ring/ring-devel "1.9.0"]
     [clj-stacktrace "0.2.8"]
     [hiccup "1.0.5"]
     [ns-tracker "0.4.0"]
       [org.clojure/java.classpath "0.3.0"]
       [org.clojure/tools.namespace "0.2.11"]
   [ring/ring-jetty-adapter "1.9.0"]
     [org.eclipse.jetty/jetty-server "9.4.31.v20200723"]
       [javax.servlet/javax.servlet-api "3.1.0"]
       [org.eclipse.jetty/jetty-http "9.4.31.v20200723"]
         [org.eclipse.jetty/jetty-util "9.4.31.v20200723"]
       [org.eclipse.jetty/jetty-io "9.4.31.v20200723"]
   [ring/ring-servlet "1.9.0"]
```

to

```
$ lein deps :tree
 [cheshire "5.10.0"]
   [com.fasterxml.jackson.core/jackson-core "2.10.2"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.10.2"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.10.2"]
   [tigris "0.1.2"]
 [clojure-complete "0.2.5" :exclusions [[org.clojure/clojure]]]
 [nrepl "0.8.3" :exclusions [[org.clojure/clojure]]]
 [org.clojure/clojure "1.10.2"]
   [org.clojure/core.specs.alpha "0.2.56"]
   [org.clojure/spec.alpha "0.2.194"]
 [ring/ring-codec "1.2.0" :exclusions [[org.clojure/clojure]]]
```

and remove some CVEs which are detected by https://github.com/rm-hull/nvd-clojure (in commons-io-2.6.jar and jetty-server-9.4.31.v20200723.jar).

Be aware this also bumps ring/ring-codec from 1.1.2 to 1.2.0.