### PR TITLE
Bump cheshire dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :comment "Author: Marc Wilhelm Küster"}
   :dependencies [[org.clojure/clojure "1.10.2"]
-                 [cheshire "5.10.0"]
+                 [cheshire "5.10.1"]
                  [ring "1.9.0" :exclusions [org.clojure/clojure]]])


### PR DESCRIPTION
This should solve a CVE as reported by https://github.com/rm-hull/nvd-clojure for jackson-dataformat-cbor-2.10.2.jar.