### PR TITLE
Multiple minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+
+# IntelliJ
+.idea/
+*.ipr
+*.iml
+*.iws

--- a/src/uritemplate_clj/match.clj
+++ b/src/uritemplate_clj/match.clj
@@ -3,7 +3,7 @@
   (:require [ring.util.codec :as codec]
             [clojure.string :as cs]))
 
-(defn find-constant-parts 
+(defn find-constant-parts
   "Find all the constants templates tokens in a given URI. Returns a list of (first last) index points for those in the URI"
   ;TODO: this implementation works only up to level 2, needs to be generalized for levels 3 and 4
   ([token-list ^String uri]
@@ -41,7 +41,7 @@
      ;; For example, {/a,b} is expanded to the tokens "/" {a} and "/" {a} "/" {b}
      ;; The resulting templates are then reparsed from the possible-path variable and handled as one possible URI template that could be matched
      (let
-         [res 
+         [res
           (for
               [cnt (range (count (:variables tok)))]
             (let
@@ -61,9 +61,9 @@
                                         ;Without this assumption no meaningful parsing seems possible
                                         ;Inded, templates of type /foo{hello}{world} are a class of non-decidable URI templates
         (if var
-          (match-token  
-           (first remaining-tokens) 
-           (rest remaining-tokens) 
+          (match-token
+           (first remaining-tokens)
+           (rest remaining-tokens)
            (subs rest-uri (count var))
            (assoc result-map (:text (first (:variables tok))) (codec/url-decode var)))
           {})))))
@@ -88,9 +88,9 @@
 (defn match-variables [^String template ^String uri]
   "Find all the parses a given uri can have against a URI template. Return this as a set of maps (possibly empty)"
   (let
-      [tokens (tokenize (cs/lower-case template))]
+      [tokens (tokenize template)]
     (set
-     (match-token (first tokens) (rest tokens) (cs/lower-case uri) {}))))
+     (match-token (first tokens) (rest tokens) uri {}))))
 
 (defn matches? [^String template ^String uri]
   "Indicates if a given URI has at least one match against a URI template"
@@ -103,7 +103,7 @@
 NULL (= %00 in the URI). This is considered the canonical URI
 representation of the template"
   (let
-      [tokens (map parse-token (filter #(= (first %) \{) (tokenize (cs/lower-case template))))
+      [tokens (map parse-token (filter #(= (first %) \{) (tokenize template)))
        all-vars (map :text (mapcat :variables tokens))
        var-map  (zipmap all-vars (repeat (count all-vars) "\u0000"))]
     (uritemplate template var-map)))
@@ -114,7 +114,7 @@ https://github.com/mwkuster/uritemplate-clj/issues/1#issuecomment-17117448
 Returns 0 if the uri matches the template, -1 if the template give a
 canonicial form is less than the URI in terms of string comparison, +1
 if it is more. It assumes that all values are filled with ASCII %00 for comparision (canonical URI representation of the template)"
-  (if 
+  (if
       (matches? template uri) 0
       (let
           [comparison-result (compare uri (fill-with-nulls template))]
@@ -122,5 +122,5 @@ if it is more. It assumes that all values are filled with ASCII %00 for comparis
           (< comparison-result 0) -1
           (> comparison-result 0) 1
           (= comparison-result 0) 0))))
-  
-    
+
+

--- a/src/uritemplate_clj/match.clj
+++ b/src/uritemplate_clj/match.clj
@@ -94,9 +94,8 @@
 
 (defn matches? [^String template ^String uri]
   "Indicates if a given URI has at least one match against a URI template"
-  (if (empty? (match-variables template uri))
-    false
-    true))
+   (or (not (empty? (match-variables template uri)))
+       (= template uri)))
 
 (defn fill-with-nulls [^String template]
   "Create a version of the template with all variables set to ASCII

--- a/src/uritemplate_clj/match.clj
+++ b/src/uritemplate_clj/match.clj
@@ -56,8 +56,8 @@
      (not (= (count (:variables tok)) 1)) {} ; error case
       :else
       (let
-          [var (re-find #"^[a-zA-Z0-9\.%,_]+" rest-uri)] 
-                                        ;this assumes that we can always parse up to the next separator. 
+          [var (re-find #"^[a-zA-Z0-9\.%,_-]+" rest-uri)]
+                                        ;this assumes that we can always parse up to the next separator.
                                         ;Without this assumption no meaningful parsing seems possible
                                         ;Inded, templates of type /foo{hello}{world} are a class of non-decidable URI templates
         (if var

--- a/test/uritemplate_clj/match_test.clj
+++ b/test/uritemplate_clj/match_test.clj
@@ -21,7 +21,14 @@
     (is (= (match-variables template uri4) (set values2)))
     (is (= (match-variables template uri5) (set values3)))))
 
-(deftest ambiguous-level3-parses-test 
+(deftest match-variables-is-case-sensitive
+  (let
+    [template "http://www.example.org/{streamId}/"
+     uri "http://www.example.org/6f56ae19-4032-4bb3-9c6f-1a0ce2fbd4c8/"
+     values {"streamId" "6f56ae19-4032-4bb3-9c6f-1a0ce2fbd4c8"}]
+    (is (= (match-variables template uri) (set values)))))
+
+(deftest ambiguous-level3-parses-test
   (let
       [ambiguous-template "/foo{/ba,bar}{/baz,bay}"
        values1 {"ba" "x", "bar" "y", "baz" "z"}
@@ -29,7 +36,7 @@
     (is (= (match-variables ambiguous-template "/foo/x/y/z") (set (list values1 values2))))))
 
 ;; The additional value to handle highly ambiguous level4 parses seems unjustified for the associated complexity
-;; (deftest ambiguous-level4-parses-test 
+;; (deftest ambiguous-level4-parses-test
 ;;   (let
 ;;       [ambiguous-template "/foo{/ba*}{/baz,bay}"
 ;;        values1 {"ba" '("x" "y"), "baz" "z"}

--- a/test/uritemplate_clj/match_test.clj
+++ b/test/uritemplate_clj/match_test.clj
@@ -4,7 +4,7 @@
         uritemplate-clj.match
         cheshire.core))
 
-(deftest simple-parses-test 
+(deftest simple-parses-test
   (let
       [template "http://www.example.org/bla/{var}/{hello}"
        uri1 "http://www.example.org/bla/v/h"
@@ -12,11 +12,14 @@
        uri3 "http://www.example.org/bla/v/h/z"
        values {"var" "v", "hello" "h"}
        uri4 "http://www.example.org/bla/v/h%20w"
-       values2 {"var" "v", "hello" "h w"}]
+       values2 {"var" "v", "hello" "h w"}
+       uri5 "http://www.example.org/bla/6f56ae19-4032-4bb3-9c6f-1a0ce2fbd4c8/example"
+       values3 {"var" "6f56ae19-4032-4bb3-9c6f-1a0ce2fbd4c8", "hello" "example"}]
     (is (= (match-variables template uri1) (set values)))
     (is (= (match-variables template uri2) #{}))
     (is (= (match-variables template uri3) #{}))
-    (is (= (match-variables template uri4) (set values2)))))
+    (is (= (match-variables template uri4) (set values2)))
+    (is (= (match-variables template uri5) (set values3)))))
 
 (deftest ambiguous-level3-parses-test 
   (let

--- a/test/uritemplate_clj/match_test.clj
+++ b/test/uritemplate_clj/match_test.clj
@@ -69,6 +69,14 @@
     (is (not (matches? template uri2)))
     (is (not (matches? template uri3)))))
 
+(deftest matches?-with-no-template-vars-test
+  (let
+    [template "http://www.example.org/no-template-vars"
+     uri1 "http://www.example.org/no-template-vars"
+     uri2 "http://www.example.org/other"]
+    (is (matches? template uri1))
+    (is (not (matches? template uri2)))))
+
 (deftest fill-with-nulls-test
   (let
       [template "http://www.example.org/bla/{var}/{hello}"


### PR DESCRIPTION
Howdy 👋 

I was working on a project two years ago where we needed to do some work related to uritemplating and at that time we ended up forking this library due to a couple of limitations. Those limitations are:

* UUIDs in match variables did not work
* Template variables were not case sensitive (seemingly intentionally?)
* "matches?" did not give a match if there were no template vars

I don't know whether all or some of these "problems" we were having a were purely because of limitations in the library or because our use case didn't fully meet the spec. Nonetheless I now have use for these "fixes" again and decided to open this PR with the fixes so that you can review it and decide whether it is something you would want to add to the library. The three fixes are independent commits so it should be straight-forward to review if each of them make sense. Open to discussing any of it as well.

Cheers
Jonas